### PR TITLE
Improve failed resolve logging

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=4.3.0
+version=4.3.1


### PR DESCRIPTION
We are currently logging the discovery address as `Optional<String>`:
> 2024-09-05 16:10:01,901 INFO  - 2024-09-05 16:10:01,900 ERROR - HiveMQ DNS Cluster Discovery Extension: Failed to resolve DNS record for address 'Optional[hivemq-hp-cluster.hivemq.svc]'.

https://dc-square.slack.com/archives/C013WEB153R/p1725620403101829