### PR TITLE
PLT-1261: declare the ECR Public registry for the base image

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -47,10 +47,17 @@ oci {
         dockerHub {
             optionalCredentials()
         }
+        registry("ecrPublic") {
+            url = uri("https://public.ecr.aws")
+            exclusiveContent { includeGroup("hivemq.base-images") }
+        }
     }
     imageMapping {
         mapModule("com.hivemq", "hivemq-enterprise") {
             toImage("hivemq/hivemq4")
+        }
+        mapGroup("hivemq.base-images") {
+            toImage(nameSpec("hivemq/base-images/") + name)
         }
     }
     imageDefinitions {


### PR DESCRIPTION
## What

Declares the ECR Public registry (and the matching image mapping) in this build's `oci {}` block.

## Why

The `eclipse-temurin` base image now comes from **ECR Public** instead of Docker Hub (PLT-941 / PLT-1261).

This build does not reference the base image directly — but it depends on `com.hivemq:hivemq-enterprise`, which are built **on** that base. gradle-oci resolves image dependencies in the context of the **consuming** project, so the registry has to be declared here too. Without it the coordinate falls through to the `dockerHub` registry and the composite build fails:

```
Could not resolve hivemq.base-images:eclipse-temurin:sha256!...
  > Could not get resource '.../docker-hub-proxy/hivemq.base-images/eclipse-temurin/...'
```

## Notes

- Literal values are used rather than the `ociImages` accessors, because this build's catalog has no `eclipse-temurin` entry (it does not consume the base image directly).
- `exclusiveContent` scopes the new registry to the `hivemq.base-images` group, so every other image still resolves exactly as before.
- Anonymous pulls — no credentials, OIDC or CI auth changes.

Verified by reproducing the failure locally and confirming this configuration resolves the transitive base image (17 blobs pulled).
